### PR TITLE
Issue with writing to closed connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ TODO
 ## Server Usage
 
 TODO
+
+## To Run
+
+You'll need three separate terminal windows, called A, B, and C for the purposes of this README.
+
+1. In terminal A, launch the splitpt server
+2. In terminal B, launch the obfs4 server
+3. In terminal C, launch the splitpt client

--- a/client/lib/client-config.go
+++ b/client/lib/client-config.go
@@ -8,20 +8,18 @@ import (
 )
 
 type SplitPTConfig struct {
-	Connections  map[string]Connections
 	SplittingAlg string
+	Connections  map[string][]struct {
+		Transport string
+		Args      []string
+		Cert      string
+	}
 }
 
-type Connections struct {
-	Transport string
-	Args      []string
-	Cert      string
-}
-
-func GetClientTOMLConfig(tomlFilename string) (*ConnectionsList, error) {
+func GetClientTOMLConfig(tomlFilename string) (*SplitPTConfig, error) {
 	log.Printf("Decoding TOML")
 	log.Printf(tomlFilename)
-	var config ConnectionsList
+	var config SplitPTConfig
 	meta, err := toml.DecodeFile(tomlFilename, &config)
 	if err != nil {
 		log.Printf("Error decoding TOML config")
@@ -33,7 +31,11 @@ func GetClientTOMLConfig(tomlFilename string) (*ConnectionsList, error) {
 		log.Printf(config.SplittingAlg)
 	default:
 		log.Printf("Invalid splitting algorithm")
-		return _, errors.New("Invalid splitting algorithm in TOML")
+		return nil, errors.New("Invalid splitting algorithm in TOML")
+	}
+	for conn := range config.Connections {
+		log.Printf("Connections: ")
+		log.Printf(conn)
 	}
 	log.Println(meta.Keys())
 	log.Println(meta.Undecoded())

--- a/client/lib/client-config.go
+++ b/client/lib/client-config.go
@@ -18,7 +18,6 @@ type SplitPTConfig struct {
 
 func GetClientTOMLConfig(tomlFilename string) (*SplitPTConfig, error) {
 	log.Printf("Decoding TOML")
-	log.Printf(tomlFilename)
 	var config SplitPTConfig
 	meta, err := toml.DecodeFile(tomlFilename, &config)
 	if err != nil {
@@ -33,9 +32,10 @@ func GetClientTOMLConfig(tomlFilename string) (*SplitPTConfig, error) {
 		log.Printf("Invalid splitting algorithm")
 		return nil, errors.New("Invalid splitting algorithm in TOML")
 	}
-	for conn := range config.Connections {
+	log.Printf("%v connections found", len(config.Connections["splitpt"]))
+	for _, conn := range config.Connections["splitpt"] {
 		log.Printf("Connections: ")
-		log.Printf(conn)
+		log.Printf(conn.Transport)
 	}
 	log.Println(meta.Keys())
 	log.Println(meta.Undecoded())

--- a/client/lib/client-config.go
+++ b/client/lib/client-config.go
@@ -13,13 +13,14 @@ type SplitPTConfig struct {
 		Transport string
 		Args      []string
 		Cert      string
+		Bridge    string
 	}
 }
 
 func GetClientTOMLConfig(tomlFilename string) (*SplitPTConfig, error) {
 	log.Printf("Decoding TOML")
 	var config SplitPTConfig
-	meta, err := toml.DecodeFile(tomlFilename, &config)
+	_, err := toml.DecodeFile(tomlFilename, &config)
 	if err != nil {
 		log.Printf("Error decoding TOML config")
 		return nil, err
@@ -32,12 +33,12 @@ func GetClientTOMLConfig(tomlFilename string) (*SplitPTConfig, error) {
 		log.Printf("Invalid splitting algorithm")
 		return nil, errors.New("Invalid splitting algorithm in TOML")
 	}
-	log.Printf("%v connections found", len(config.Connections["splitpt"]))
-	for _, conn := range config.Connections["splitpt"] {
+	log.Printf("%v connections found", len(config.Connections["connections"]))
+	for _, conn := range config.Connections["connections"] {
 		log.Printf("Connections: ")
 		log.Printf(conn.Transport)
+		log.Printf(conn.Cert)
+		log.Printf(conn.Bridge)
 	}
-	log.Println(meta.Keys())
-	log.Println(meta.Undecoded())
 	return &config, nil
 }

--- a/client/lib/client-config.go
+++ b/client/lib/client-config.go
@@ -1,14 +1,15 @@
 package splitpt_client
 
 import (
+	"errors"
 	"log"
 
 	"github.com/BurntSushi/toml"
 )
 
-type ConnectionsList struct {
+type SplitPTConfig struct {
 	Connections  map[string]Connections
-	Splittingalg string
+	SplittingAlg string
 }
 
 type Connections struct {
@@ -26,7 +27,14 @@ func GetClientTOMLConfig(tomlFilename string) (*ConnectionsList, error) {
 		log.Printf("Error decoding TOML config")
 		return nil, err
 	}
-	log.Printf(config.Splittingalg)
+
+	switch config.SplittingAlg {
+	case "round-robin":
+		log.Printf(config.SplittingAlg)
+	default:
+		log.Printf("Invalid splitting algorithm")
+		return _, errors.New("Invalid splitting algorithm in TOML")
+	}
 	log.Println(meta.Keys())
 	log.Println(meta.Undecoded())
 	return &config, nil

--- a/client/lib/lyrebird.go
+++ b/client/lib/lyrebird.go
@@ -10,7 +10,7 @@ import (
 	"github.com/txthinking/socks5"
 )
 
-func LyrebirdConnect() (*socks5.Client, error) {
+func LyrebirdConnect(args *[]string, cert string) (*socks5.Client, error) {
 	log.Printf("Conecting to Lyrebird")
 	ptchan := make(chan string)
 	pterr := make(chan error)

--- a/client/lib/lyrebird.go
+++ b/client/lib/lyrebird.go
@@ -1,0 +1,81 @@
+package splitpt_client
+
+import (
+	"bufio"
+	"context"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/txthinking/socks5"
+)
+
+func LyrebirdConnect() (*socks5.Client, error) {
+	log.Printf("Conecting to Lyrebird")
+	ptchan := make(chan string)
+	pterr := make(chan error)
+	ptshutdown := make(chan struct{})
+
+	ctx := context.Background()
+	ptproc := exec.CommandContext(ctx, "lyrebird", "-enableLogging", "-logLevel", "DEBUG")
+	//log.Printf(ptproc.Env)
+	ptproc.Env = append(ptproc.Environ(), "TOR_PT_MANAGED_TRANSPORT_VER=1")
+	ptproc.Env = append(ptproc.Environ(), "TOR_PT_EXIT_ON_STDIN_CLOSE=0")
+	ptproc.Env = append(ptproc.Environ(), "TOR_PT_CLIENT_TRANSPORTS=obfs4")
+	ptproc.Env = append(ptproc.Environ(), "TOR_PT_STATE_LOCATION=../pt-setup/client-state/")
+
+	log.Printf("Getting stdoutpipe")
+	ptprocout, err := ptproc.StdoutPipe()
+	if err != nil {
+		log.Printf("Error getting stdout pipe")
+		pterr <- err
+	}
+	log.Printf("Starting ptproc")
+	err1 := ptproc.Start()
+	if err1 != nil {
+		log.Printf("Error starting PT process: %s", err1.Error())
+		pterr <- err1
+	}
+
+	log.Printf("Scanning for SOCKS address")
+	go func() {
+		scanner := bufio.NewScanner(ptprocout)
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), "socks5") {
+				line := strings.Split(scanner.Text(), " ")
+				ptchan <- line[3]
+				log.Printf("Got SOCKS5 addr")
+				break
+			} else {
+				continue
+			}
+		}
+		if err2 := scanner.Err(); err2 != nil {
+			log.Printf("Error scanning for socks5 addr: %s", err2.Error())
+			pterr <- err2
+		}
+		<-ptshutdown
+		err3 := ptproc.Wait()
+		if err3 != nil {
+			log.Printf("Error completing command: %s", err3.Error())
+		}
+	}()
+
+	var socks5addr string
+	select {
+	case socks5addr = <-ptchan:
+		log.Printf("SOCKS5 addr: %s", socks5addr)
+	case err := <-pterr:
+		log.Printf("pterr had something in it")
+		return nil, err
+	}
+
+	log.Printf("Getting Lyrebird SOCKS client")
+	client, err := socks5.NewClient(socks5addr, "cert=xmK64YEbi2h1aZC5P5s7MyiUN8gmypIRDnaiRKmB4/qT0lGkaAglYlzKPrkpc4I2PHhVNg;iat-mode=0", "\x00", 60, 0)
+	if err != nil {
+		log.Printf("Error connecting to pt")
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/client/lib/lyrebird.go
+++ b/client/lib/lyrebird.go
@@ -71,7 +71,7 @@ func LyrebirdConnect(args *[]string, cert string) (*socks5.Client, error) {
 	}
 
 	log.Printf("Getting Lyrebird SOCKS client")
-	client, err := socks5.NewClient(socks5addr, "cert=xmK64YEbi2h1aZC5P5s7MyiUN8gmypIRDnaiRKmB4/qT0lGkaAglYlzKPrkpc4I2PHhVNg;iat-mode=0", "\x00", 60, 0)
+	client, err := socks5.NewClient(socks5addr, "cert=xmK64YEbi2h1aZC5P5s7MyiUN8gmypIRDnaiRKmB4/qT0lGkaAglYlzKPrkpc4I2PHhVNg;iat-mode=0", "\x00", 0, 0)
 	if err != nil {
 		log.Printf("Error connecting to pt")
 		return nil, err

--- a/client/lib/splitpt.go
+++ b/client/lib/splitpt.go
@@ -104,17 +104,14 @@ func (t *SplitPTClient) GetPTConnections() ([]net.Conn, error) {
 		log.Printf("Error resolving TCP address: %s", err.Error())
 		return nil, err
 	}
-	for i := 0; i < 1; i++ {
-		//for _, conn := range t.Connections["splitpt"] {
+	for _, conn := range t.Connections["connections"] {
 		var client *socks5.Client
 		//log.Printf("conn.Transport: %s", conn.Transport)
-		//if conn.Transport == "lyrebird" {
-		if true {
+		if conn.Transport == "lyrebird" {
 			// TODO need interface for this i guess?
 			log.Printf("Launching Lyrebird connection")
 			//	client, err = LyrebirdConAnect(&conn.Args, conn.Cert)
-			args := []string{"", ""}
-			client, err = LyrebirdConnect(&args, "")
+			client, err = LyrebirdConnect(&conn.Args, conn.Cert)
 			if err != nil {
 				log.Printf("Error connecting to lyrebird: %s", err.Error())
 				return nil, err

--- a/client/splitpt-config.toml
+++ b/client/splitpt-config.toml
@@ -1,12 +1,12 @@
-splittingalg = "random"
+splittingalg = "round-robin"
 
-[[connections]]
+[[splitpt.connections]]
 
 transport = "lyrebird"
 args = ["", ""]
 cert = ""
 
-[[connections]]
+[[splitpt.connections]]
 
 transport = "webtunnel"
 args = ["",""]

--- a/client/splitpt-config.toml
+++ b/client/splitpt-config.toml
@@ -6,8 +6,3 @@ transport = "lyrebird"
 args = ["", ""]
 cert = ""
 
-[[splitpt.connections]]
-
-transport = "webtunnel"
-args = ["",""]
-cert = ""

--- a/client/splitpt-config.toml
+++ b/client/splitpt-config.toml
@@ -1,8 +1,17 @@
 splittingalg = "round-robin"
 
-[[splitpt.connections]]
+[[connections.connections]]
 
 transport = "lyrebird"
 args = ["", ""]
-cert = ""
+cert = "xxx"
+bridge = "yyy"
+
+[[connections.connections]]
+
+transport = "lyrebird"
+args = ["", ""]
+cert = "xxx"
+bridge = "yyy"
+
 

--- a/client/splitpt.go
+++ b/client/splitpt.go
@@ -27,13 +27,13 @@ func copyLoop(socks *pt.SocksConn, sptstream *smux.Stream) {
 	done := make(chan struct{}, 2)
 	go func() {
 		if _, err := io.Copy(socks, sptstream); err != nil {
-			log.Printf("copying to SOCKS resulted in error: %v", err)
+			log.Printf("[copyLoop] copying to SOCKS resulted in error: %v", err)
 		}
 		done <- struct{}{}
 	}()
 	go func() {
 		if _, err := io.Copy(sptstream, socks); err != nil {
-			log.Printf("copying to SOCKS resulted in error: %v", err)
+			log.Printf("[copyLoop] copying from SOCKS resulted in error: %v", err)
 			done <- struct{}{}
 		}
 	}()
@@ -63,7 +63,7 @@ func socksAcceptLoop(ln *pt.SocksListener, sptConfig *spt.SplitPTConfig, shutdow
 				conn.Reject()
 				return
 			}
-
+			log.Printf("Dialing...")
 			sconn, err := transport.Dial()
 			if err != nil {
 				log.Printf("Dial error: %s", err)
@@ -76,6 +76,7 @@ func socksAcceptLoop(ln *pt.SocksListener, sptConfig *spt.SplitPTConfig, shutdow
 			copyLoop(conn, sconn)
 		}()
 	}
+	log.Printf("Returning from socksAcceptLoop")
 	return nil
 }
 

--- a/client/splitpt.go
+++ b/client/splitpt.go
@@ -41,7 +41,7 @@ func copyLoop(socks *pt.SocksConn, sptstream *smux.Stream) {
 	log.Printf("copy loop done")
 }
 
-func socksAcceptLoop(ln *pt.SocksListener, tomlConfig *spt.ConnectionsList, shutdown chan struct{}, wg *sync.WaitGroup) error {
+func socksAcceptLoop(ln *pt.SocksListener, sptConfig *spt.SplitPTConfig, shutdown chan struct{}, wg *sync.WaitGroup) error {
 	log.Printf("socksAcceptLoop()")
 	defer ln.Close()
 	for {
@@ -57,7 +57,7 @@ func socksAcceptLoop(ln *pt.SocksListener, tomlConfig *spt.ConnectionsList, shut
 
 		go func() {
 			defer wg.Done()
-			transport, err := spt.NewSplitPTClient(tomlConfig)
+			transport, err := spt.NewSplitPTClient(*sptConfig)
 			if err != nil {
 				log.Printf("Transport error: %s", err)
 				conn.Reject()
@@ -124,7 +124,7 @@ func main() {
 		log.Printf("toml filename cannot be empty")
 		return
 	}
-	tomlConfig, err := spt.GetClientTOMLConfig(*tomlFilename)
+	sptConfig, err := spt.GetClientTOMLConfig(*tomlFilename)
 	if err != nil {
 		log.Printf("Error with toml config: %v", err)
 		return
@@ -162,7 +162,7 @@ func main() {
 				break
 			}
 			log.Printf("Started SOCKS listenener at %v", ln.Addr())
-			go socksAcceptLoop(ln, tomlConfig, shutdown, &wg)
+			go socksAcceptLoop(ln, sptConfig, shutdown, &wg)
 			pt.Cmethod(methodName, ln.Version(), ln.Addr())
 			listeners = append(listeners, ln)
 		default:

--- a/common/split/round-robin.go
+++ b/common/split/round-robin.go
@@ -1,0 +1,191 @@
+package split
+
+import (
+	"bufio"
+	"errors"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var errNotImplemented = errors.New("not implemented")
+
+// stringAddr satisfies the net.Addr interface using fixed strings for the
+// Network and String methods.
+type stringAddr struct{ network, address string }
+
+// RoundRobinPacketConn implements the net.PacketConn interface by continually
+//
+// Every Turbo Tunnel design will need some sort of PacketConn adapter that
+// adapts the session layer's sequence of packets to the obfuscation layer. But
+// not every such adapter will look like RoundRobinPacketConn. It depends on what
+// the obfuscation layer looks like. Some obfuscation layers will not need a
+// persistent connection. One could, for example, handle every ReadFrom or
+// WriteTo as an independent network operation.
+type RoundRobinPacketConn struct {
+	sessionID  SessionID
+	remoteAddr net.Addr
+	recvQueue  chan []byte
+	sendQueue  chan []byte
+	closeOnce  sync.Once
+	closed     chan struct{}
+	ptconn     net.Conn
+	// What error to return when the RoundRobinPacketConn is closed.
+	err atomic.Value
+}
+
+func NewRoundRobinPacketConn(sessionID SessionID, ptconn net.Conn) *RoundRobinPacketConn {
+	c := &RoundRobinPacketConn{
+		sessionID:  sessionID,
+		remoteAddr: ptconn.RemoteAddr(),
+		recvQueue:  make(chan []byte, 32),
+		sendQueue:  make(chan []byte, 32),
+		closed:     make(chan struct{}),
+		ptconn:     ptconn,
+	}
+	go func() {
+		c.closeWithError(c.loop())
+	}()
+	return c
+}
+
+// loop dials c.remoteAddr in a loop, exchanging packets on each new connection
+// as long as it lasts. Only errors in dialing break the loop and report the
+// error to the caller.
+func (c *RoundRobinPacketConn) loop() error {
+	for {
+		select {
+		case <-c.closed:
+			return nil
+		default:
+		}
+		log.Printf("session %v: redialing %v", c.sessionID, c.remoteAddr)
+		err := c.dialAndExchange()
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (c *RoundRobinPacketConn) dialAndExchange() error {
+	conn := c.ptconn // <- get the correct conn here
+	defer conn.Close()
+
+	// Begin by sending the session identifier; everything after that is
+	// encapsulated packets.
+	_, err := conn.Write(c.sessionID[:])
+	if err != nil {
+		// Errors after the dial are not fatal but cause a redial.
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	done := make(chan struct{})
+	// Read encapsulated packets from the connection and write them to
+	// c.recvQueue.
+	go func() {
+		defer wg.Done()
+		defer close(done) // Signal the write loop to finish.
+		br := bufio.NewReader(conn)
+		for {
+			p, err := ReadPacket(br)
+			if err != nil {
+				return
+			}
+			select {
+			case <-c.closed:
+				return
+			case c.recvQueue <- p:
+			}
+		}
+	}()
+	// Read packets from c.sendQueue and encapsulate them into the
+	// connection.
+	go func() {
+		defer wg.Done()
+		defer conn.Close() // Signal the read loop to finish.
+		bw := bufio.NewWriter(conn)
+		for {
+			select {
+			case <-c.closed:
+				return
+			case <-done:
+				return
+			case p := <-c.sendQueue:
+				err := WritePacket(bw, p)
+				if err != nil {
+					return
+				}
+				err = bw.Flush()
+				if err != nil {
+					return
+				}
+			}
+		}
+	}()
+
+	// Exchange packets until the connection is terminated.
+	wg.Wait()
+	return nil
+}
+
+func (c *RoundRobinPacketConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	select {
+	case <-c.closed:
+		return 0, nil, &net.OpError{Op: "read", Net: c.remoteAddr.Network(), Source: c.sessionID, Addr: c.remoteAddr, Err: c.err.Load().(error)}
+	default:
+	}
+	select {
+	case <-c.closed:
+		return 0, nil, &net.OpError{Op: "read", Net: c.remoteAddr.Network(), Source: c.sessionID, Addr: c.remoteAddr, Err: c.err.Load().(error)}
+	case buf := <-c.recvQueue:
+		return copy(p, buf), c.remoteAddr, nil
+	}
+}
+
+func (c *RoundRobinPacketConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	select {
+	case <-c.closed:
+		return 0, &net.OpError{Op: "write", Net: c.remoteAddr.Network(), Source: c.sessionID, Addr: c.remoteAddr, Err: c.err.Load().(error)}
+	default:
+	}
+	// Copy the slice so that the caller may reuse p.
+	buf := make([]byte, len(p))
+	copy(buf, p)
+	select {
+	case c.sendQueue <- buf:
+	default: // Silently drop outgoing packets if the send queue is full.
+	}
+	return len(buf), nil
+}
+
+// closeWithError unblocks pending operations and makes future operations fail
+// with the given error. If err is nil, it becomes errClosed.
+func (c *RoundRobinPacketConn) closeWithError(err error) error {
+	firstClose := false
+	c.closeOnce.Do(func() {
+		firstClose = true
+		// Store the error that will be returned for future operations.
+		if err == nil {
+			err = errClosed
+		}
+		c.err.Store(err)
+		close(c.closed)
+	})
+	if !firstClose {
+		return &net.OpError{Op: "close", Net: c.remoteAddr.Network(), Source: c.sessionID, Addr: c.remoteAddr, Err: c.err.Load().(error)}
+	}
+	return nil
+}
+
+func (c *RoundRobinPacketConn) Close() error { return c.closeWithError(nil) }
+
+func (c *RoundRobinPacketConn) LocalAddr() net.Addr  { return c.sessionID }
+func (c *RoundRobinPacketConn) RemoteAddr() net.Addr { return c.remoteAddr }
+
+func (c *RoundRobinPacketConn) SetDeadline(t time.Time) error      { return errNotImplemented }
+func (c *RoundRobinPacketConn) SetReadDeadline(t time.Time) error  { return errNotImplemented }
+func (c *RoundRobinPacketConn) SetWriteDeadline(t time.Time) error { return errNotImplemented }

--- a/common/split/round-robin.go
+++ b/common/split/round-robin.go
@@ -80,7 +80,7 @@ func (c *RoundRobinPacketConn) loop() error {
 			return nil
 		default:
 		}
-		log.Printf("session %v: redialing %v", c.sessionID, c.remoteAddr)
+		log.Printf("[RR Packet Conn] session %v: redialing %v", c.sessionID, c.remoteAddr)
 		err := c.exchange()
 		if err != nil {
 			return err
@@ -97,7 +97,7 @@ func (c *RoundRobinPacketConn) exchange() error {
 		if err != nil {
 			// TODO: Because we don't currently have a redial mechanism,
 			// errors are fatal
-			log.Printf("Error writing to conn %s", err.Error())
+			log.Printf("[RR Packet Conn] Error writing to conn %s", err.Error())
 			return err
 		}
 	}


### PR DESCRIPTION
In the round-robin packet conn, there's an issue with copying to a conn:  `Error writing to conn write tcp 127.0.0.1:60557->127.0.0.1:60556: use of closed connection`

This might be an issue with the dummy{} addr being passed to the packet conn?

Should the dummy be one of the bridges we want to use to split? 